### PR TITLE
Fix alert type assignment bug

### DIFF
--- a/DrissionPage/chromium_page.py
+++ b/DrissionPage/chromium_page.py
@@ -374,7 +374,7 @@ class ChromiumPage(ChromiumBase):
         """alert出现时触发的方法"""
         self._alert.activated = True
         self._alert.text = kwargs['message']
-        self._alert.type = kwargs['message']
+        self._alert.type = kwargs.get('type')
         self._alert.defaultPrompt = kwargs.get('defaultPrompt', None)
         self._alert.response_accept = None
         self._alert.response_text = None


### PR DESCRIPTION
## Summary
- fix alert type not assigned correctly in `_on_alert_open`

## Testing
- `python -m compileall -q DrissionPage`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684ce2bc39648328b30f559fccb52646